### PR TITLE
Improve HF integration (making sure downloads work, better discoverability)

### DIFF
--- a/models/aim.py
+++ b/models/aim.py
@@ -5,8 +5,10 @@ from .stage2.config_mamba import MambaConfig
 from .stage2.mixer_seq_simple import MambaLMHeadModel
 from .stage1.vq_model import VQ_models
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class AiM(nn.Module):
+
+class AiM(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/hp-l33/AiM", pipeline_tag="unconditional-image-generation", license="mit"):
     def __init__(self, config: MambaConfig):
         super().__init__()
         # init all models


### PR DESCRIPTION
Hi @hp-l33 and team,

Thanks for this nice work! I see the models are already on the [hub](https://huggingface.co/hp-l33/aim) which is great. This PR aims to improve the integration, by ensuring:

- download stats work, with separate model repos per checkpoint (as done with libraries like Transformers)
- better discoverability (making sure tags are added so that people find them when searching https://huggingface.co/models?pipeline_tag=unconditional-image-generation)
- have safetensors serialization

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various AiM models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from aim import AiM

# load model
model = AiM()

# equip with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("your-hf-organzation-or-username/aim-base")

# reload
model = AiM.from_pretrained("your-hf-organzation-or-username/aim-base")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. We could push all checkpoints to separate repos to an organization on the hub or your personal user account if you're interested.

Would you be interested in this integration?

Kind regards,

Niels